### PR TITLE
Don't include @tailify/babel-preset as part of this preset

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,8 +12,5 @@ module.exports = () => ({
       },
     ],
   ],
-  presets: [
-    ['@tailify', { browser: true }],
-    ['@babel/preset-react', { development: isDevelopment, useBuiltIns: true }],
-  ],
+  presets: [['@babel/preset-react', { development: isDevelopment, useBuiltIns: true }]],
 });

--- a/package.json
+++ b/package.json
@@ -21,21 +21,18 @@
   "homepage": "https://github.com/tailify/babel-preset-react#readme",
   "dependencies": {
     "@babel/preset-react": "7.0.0",
-    "@tailify/babel-preset": "2.2.0",
     "babel-plugin-react-css-modules": "5.2.4"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@tailify/eslint-config-legacy": "^1.0.0",
     "@tailify/prettier-config": "^1.0.0",
-    "core-js": "^3.0.0",
     "eslint": "^5.9.0",
     "jest": "^24.7.0",
     "prettier": "^1.15.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0",
-    "core-js": "^3.0.0"
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=8"

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should not contain invalid rules 1`] = `
+"var _jsxFileName = \\"\\";
+React.createElement(Foo, {
+  bar: \\"baz\\",
+  __source: {
+    fileName: _jsxFileName,
+    lineNumber: 1
+  },
+  __self: this
+});"
+`;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -3,12 +3,12 @@
 const babel = require('@babel/core');
 
 test('should not contain invalid rules', () => {
-  const result = babel.transform('let b = 1; a ** b;', {
+  const result = babel.transform('<Foo bar="baz" />', {
     babelrc: false,
     presets: ['./lib/index.js'],
     sourceType: 'script',
   });
 
   expect(result).toBeTruthy();
-  expect(result.code).toBe('var b = 1;\nMath.pow(a, b);');
+  expect(result.code).toMatchSnapshot();
 });


### PR DESCRIPTION
We shouldn't be mixing both preset-env and preset-react into one preset. This is not best practice. This was noticed when Babel wasn't correctly picking up some of the options in the preset-env package when using just this preset.